### PR TITLE
Refactor: Shorten code, improve comments, extract narration prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import short_video
 from openai_client import initialize_openai_client
 import openai # For type hinting
 
-DEFAULT_NARRATION_PROMPT_FILENAME = "narration_prompt.txt"
+DEFAULT_NARRATION_PROMPT_FILENAME = "resources/narration_prompt.txt"
 
 class AppConfig:
     """Application configuration."""
@@ -145,11 +145,10 @@ def generate_script_and_image_prompts(
 ) -> Tuple[str, List[Dict[str, str]], List[str]]:
     """Generates script and image prompts. Loads from files if they exist."""
     response_file = os.path.join(config.base_output_dir, "response.txt")
-    data_file = os.path.join(config.base_output_dir, "data.json")
 
     raw_response_text: str
-    if os.path.exists(response_file) and os.path.exists(data_file):
-        print(f"Loading existing script from {os.path.basename(response_file)} and {os.path.basename(data_file)}.")
+    if os.path.exists(response_file) :
+        print(f"Loading existing script from {os.path.basename(response_file)}.")
         with open(response_file, 'r', encoding='utf-8') as f:
             raw_response_text = f.read()
     else:
@@ -181,12 +180,6 @@ def generate_script_and_image_prompts(
             sys.exit(1)
 
     parsed_data, narration_sentences = short_narration.parse_narration_text(raw_response_text)
-
-    # Save parsed data if it wasn't loaded or the data file didn't exist
-    if not os.path.exists(data_file) or not (os.path.exists(response_file) and os.path.exists(data_file)):
-        with open(data_file, "w", encoding='utf-8') as f:
-            json.dump(parsed_data, f, ensure_ascii=False, indent=2)
-        print(f"Parsed data saved to {data_file}")
 
     return raw_response_text, parsed_data, narration_sentences
 

--- a/main.py
+++ b/main.py
@@ -16,49 +16,19 @@ from typing import Dict, Any, List, Tuple, Optional
 import short_narration
 import short_images
 import short_video
-from openai_client import initialize_openai_client # Corrected import
+from openai_client import initialize_openai_client
 import openai # For type hinting
 
-# System prompt for YouTube Short narration generation (defined once)
-NARRATION_SYSTEM_PROMPT_TEXT = """You are a YouTube short narration generator. You generate 50 seconds to 70 seconds of narration. The shorts you create have a background that fades from image to image as the narration is going on.
-
-You will need to generate descriptions of images for each of the sentences. The image descriptions should use the key words from the content they describe. They will be passed to an AI image generator. DO NOT IN ANY CIRCUMSTANCES use names of celebrities or people in the image descriptions. It is illegal to generate images of celebrities. Only describe persons without their names. Do not reference any real person or group in the image descriptions. Don't mention the female figure or other sexual content in the images because they are not allowed.
-
-You are however allowed to use any content, including real names in the narration. Only image descriptions are restricted.
-
-Note that the narration will be fed into a text-to-speech engine, so don't use special characters.
-
-Respond with a pair of an image description in square brackets and a narration below it. Both of them should be on their own lines, as follows:
-
-###
-
-[Description of a background image]
-
-Narrator: "One sentence of narration"
-
-[Description of a background image]
-
-Narrator: "One sentence of narration"
-
-[Description of a background image]
-
-Narrator: "One sentence of narration"
-
-###
-
-The short should be 6 sentences maximum.
-
-You should add a description of a fitting backround image in between all of the narrations. It will later be used to generate an image with AI.
-"""
+DEFAULT_NARRATION_PROMPT_FILENAME = "narration_prompt.txt"
 
 class AppConfig:
-    """Holds all configuration for the application."""
+    """Application configuration."""
     def __init__(self, source_file_path: str, settings_file_path: Optional[str]):
         # File paths
         self.source_file_path: str = source_file_path
         self.settings_file_path: Optional[str] = settings_file_path
 
-        # Derived paths (initialized in _setup_paths)
+        # Derived paths
         self.short_name: str = ""
         self.base_output_dir: str = ""
         self.narration_output_dir: str = ""
@@ -82,13 +52,39 @@ class AppConfig:
         self.fade_duration_ms: int = 1000
 
         self.caption_settings: Dict[str, Any] = {}
-        self.narration_system_prompt: str = NARRATION_SYSTEM_PROMPT_TEXT
+        self.narration_system_prompt: str = "" # Loaded in _load_narration_prompt
 
-        self._load_settings_from_file() # Load from JSON, potentially overriding above
-        self._setup_paths() # Setup derived paths
+        self._load_settings_from_file()
+        self._load_narration_prompt()
+        self._setup_paths()
+
+    def _load_narration_prompt(self, prompt_filename: str = DEFAULT_NARRATION_PROMPT_FILENAME) -> None:
+        """Loads the narration system prompt from a file."""
+        try:
+            # First, check if a custom prompt path is in settings_file_path (if one exists)
+            custom_prompt_path = None
+            if self.settings_file_path and os.path.exists(self.settings_file_path):
+                with open(self.settings_file_path, 'r', encoding='utf-8') as f:
+                    json_settings = json.load(f)
+                    custom_prompt_path = json_settings.get("NARRATION_SYSTEM_PROMPT_FILE")
+
+            prompt_file_to_load = custom_prompt_path or prompt_filename
+
+            with open(prompt_file_to_load, 'r', encoding='utf-8') as f:
+                self.narration_system_prompt = f.read()
+            print(f"Loaded narration prompt from {prompt_file_to_load}")
+        except FileNotFoundError:
+            print(f"Error: Narration prompt file not found at {prompt_file_to_load}. Please create it or check path.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error reading narration prompt file {prompt_file_to_load}: {e}")
+            sys.exit(1)
+
 
     def _load_settings_from_file(self) -> None:
-        if not self.settings_file_path:
+        """Loads settings from a JSON file, overriding defaults."""
+        if not self.settings_file_path or not os.path.exists(self.settings_file_path):
+            print(f"Info: Settings file not provided or not found at {self.settings_file_path}. Using default/env settings.")
             return
         try:
             with open(self.settings_file_path, 'r', encoding='utf-8') as f:
@@ -107,17 +103,17 @@ class AppConfig:
             self.frame_rate = json_settings.get("FRAME_RATE", self.frame_rate)
             self.fade_duration_ms = json_settings.get("FADE_DURATION_MS", self.fade_duration_ms)
 
-            self.caption_settings = json_settings.get("CAPTION_SETTINGS", self.caption_settings) # Ensure default is kept if not in file
-            self.narration_system_prompt = json_settings.get("NARRATION_SYSTEM_PROMPT", self.narration_system_prompt)
+            self.caption_settings = json_settings.get("CAPTION_SETTINGS", self.caption_settings)
+            # NARRATION_SYSTEM_PROMPT is now loaded by _load_narration_prompt
+            # but users can specify a different file via NARRATION_SYSTEM_PROMPT_FILE in JSON
             print(f"Loaded and applied settings from {self.settings_file_path}")
-        except FileNotFoundError:
-            print(f"Info: Settings file not found at {self.settings_file_path}. Using default/env settings.")
         except json.JSONDecodeError:
             print(f"Warning: Could not decode JSON from {self.settings_file_path}. Using default/env settings.")
         except Exception as e:
             print(f"Error reading settings file {self.settings_file_path}: {e}. Using default/env settings.")
 
     def _setup_paths(self) -> None:
+        """Sets up output directory paths based on the source file name."""
         self.short_name = os.path.splitext(os.path.basename(self.source_file_path))[0]
         self.base_output_dir = os.path.join("shorts", self.short_name)
         self.narration_output_dir = os.path.join(self.base_output_dir, "narrations")
@@ -135,7 +131,7 @@ def load_source_material(file_path: str) -> str:
         with open(file_path, 'r', encoding='utf-8') as f:
             return f.read()
     except FileNotFoundError:
-        print(f"Error: Source file not found at {file_path}")
+        print(f"Error: Source file not found: {file_path}")
         sys.exit(1)
     except Exception as e:
         print(f"Error reading source file {file_path}: {e}")
@@ -147,21 +143,23 @@ def generate_script_and_image_prompts(
     source_material_text: str,
     config: AppConfig
 ) -> Tuple[str, List[Dict[str, str]], List[str]]:
-    """
-    Generates narration script and image prompts using OpenAI.
-    Saves response and parsed data to files. If files exist, loads from them.
-    """
+    """Generates script and image prompts. Loads from files if they exist."""
     response_file = os.path.join(config.base_output_dir, "response.txt")
     data_file = os.path.join(config.base_output_dir, "data.json")
 
     raw_response_text: str
     if os.path.exists(response_file) and os.path.exists(data_file):
-        print(f"Found existing {os.path.basename(response_file)} and {os.path.basename(data_file)}. Loading script.")
+        print(f"Loading existing script from {os.path.basename(response_file)} and {os.path.basename(data_file)}.")
         with open(response_file, 'r', encoding='utf-8') as f:
             raw_response_text = f.read()
     else:
         print("Generating script with OpenAI...")
         try:
+            # Ensure narration_system_prompt is loaded
+            if not config.narration_system_prompt:
+                print("Error: Narration system prompt is not loaded.")
+                sys.exit(1)
+
             response = oai_client.chat.completions.create(
                 model=config.openai_script_model,
                 messages=[
@@ -170,20 +168,22 @@ def generate_script_and_image_prompts(
                 ]
             )
             raw_response_text = response.choices[0].message.content or ""
+            # Basic sanitization
             raw_response_text = raw_response_text.replace("’", "'").replace("`", "'").replace("…", "...").replace("“", '"').replace("”", '"')
             with open(response_file, "w", encoding='utf-8') as f:
                 f.write(raw_response_text)
             print(f"Script saved to {response_file}")
         except openai.APIError as e:
-            print(f"OpenAI API Error during script generation: {e}")
+            print(f"OpenAI API Error (script generation): {e}")
             sys.exit(1)
         except Exception as e:
-            print(f"Unexpected error during script generation: {e}")
+            print(f"Error (script generation): {e}")
             sys.exit(1)
 
     parsed_data, narration_sentences = short_narration.parse_narration_text(raw_response_text)
 
-    if not (os.path.exists(response_file) and os.path.exists(data_file)) or not os.path.exists(data_file):
+    # Save parsed data if it wasn't loaded or the data file didn't exist
+    if not os.path.exists(data_file) or not (os.path.exists(response_file) and os.path.exists(data_file)):
         with open(data_file, "w", encoding='utf-8') as f:
             json.dump(parsed_data, f, ensure_ascii=False, indent=2)
         print(f"Parsed data saved to {data_file}")
@@ -192,71 +192,71 @@ def generate_script_and_image_prompts(
 
 
 def main() -> None:
-    """Main execution function."""
+    """Main script execution."""
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <source_file_path> [settings_file_path]")
+        print(f"Usage: {sys.argv[0]} <source_file_path> [settings_file_path] [skip-video]")
         sys.exit(1)
 
     source_file_arg = sys.argv[1]
     settings_file_arg = sys.argv[2] if len(sys.argv) > 2 else None
     skip_video = (sys.argv[3] == "skip-video") if len(sys.argv) > 3 else False
 
-    # --- Initialize Configuration ---
+    # Initialize Configuration
     config = AppConfig(source_file_path=source_file_arg, settings_file_path=settings_file_arg)
     print(f"Processing short: {config.short_name}")
-    print(f"Output will be in: {config.base_output_dir}")
+    print(f"Output directory: {config.base_output_dir}")
 
-    # --- Load source material ---
+    # Load source material
     source_material_content = load_source_material(config.source_file_path)
 
-    # --- Initialize API Clients ---
+    # Initialize API Clients
     try:
         oai_client = initialize_openai_client(api_key=config.openai_api_key, base_url=config.openai_base_url)
-        short_images.set_openai_client(oai_client) # For modules that might use a global client
+        short_images.set_openai_client(oai_client) # Set client for short_images module
     except ValueError as e:
         print(f"Error initializing OpenAI client: {e}")
         sys.exit(1)
 
-    if config.azure_api_key and config.azure_region:
-        short_narration.initialize_azure_credentials(config.azure_api_key, config.azure_region)
-    else:
-        print("Warning: Azure API key or region not fully configured in AppConfig. Narration might fail.")
+    if not config.azure_api_key or not config.azure_region:
+        print("Warning: Azure API key/region not fully configured. Narration might fail.")
+    # Azure credentials will be passed directly to create_narration_audio_files
 
-    # --- Script Generation ---
+    # Script Generation
     _, parsed_script_data, narrations_list = generate_script_and_image_prompts(
         oai_client, source_material_content, config
     )
     if not narrations_list:
-        print("No narration sentences were generated or parsed. Exiting.")
+        print("No narration sentences generated/parsed. Exiting.")
         sys.exit(1)
 
-    # --- Narration Generation ---
+    # Narration Generation
     print("Generating narration audio...")
     short_narration.create_narration_audio_files(
         data=parsed_script_data,
         output_folder=config.narration_output_dir,
-        azure_subscription_key=config.azure_api_key, # Pass explicitly
-        azure_region=config.azure_region           # Pass explicitly
+        azure_subscription_key=config.azure_api_key,
+        azure_region=config.azure_region
     )
 
-    # --- Image Generation ---
+    # Image Generation
     print("Generating images...")
     short_images.create_from_data(
         data=parsed_script_data,
         output_dir=config.image_output_dir,
         client=oai_client,
-        image_model=config.openai_image_model # Ensure image model is passed
+        image_model=config.openai_image_model
     )
 
     if skip_video:
-        print("Skipping video generation.")
+        print("Skipping video generation as requested.")
         return
-    # --- Video Creation ---
+
+    # Video Creation
     print("Generating video...")
     short_video.create_short_video(
         narration_sentences=narrations_list,
         base_dir=config.base_output_dir,
-        final_output_filename=os.path.basename(config.final_video_file_path),
+        final_output_filename=os.path.basename(config.final_video_file_path), # Get just filename
         caption_settings=config.caption_settings,
         video_width=config.video_width,
         video_height=config.video_height,

--- a/short_narration.py
+++ b/short_narration.py
@@ -3,44 +3,15 @@ from typing import List, Dict, Tuple, Optional
 
 from azure.cognitiveservices import speech as speechsdk
 
-# Global store for Azure credentials, can be set by main.py via initialize_azure_credentials
-_azure_credentials: Optional[Dict[str, str]] = None
-
-def initialize_azure_credentials(api_key: str, region: str) -> None:
-    """
-    Initializes Azure credentials for speech synthesis.
-    This function is intended to be called by main.py.
-    Args:
-        api_key: Azure Speech Service API key.
-        region: Azure Speech Service region.
-    Raises:
-        ValueError: If api_key or region is not provided.
-    """
-    global _azure_credentials
-    if not api_key or not region:
-        raise ValueError("Azure API key and region must be provided for initialization.")
-    _azure_credentials = {"api_key": api_key, "region": region}
-
-def _get_initialized_azure_credentials() -> Dict[str, str]:
-    """
-    Retrieves the initialized Azure credentials.
-    Raises RuntimeError if credentials have not been set via initialize_azure_credentials.
-    """
-    if _azure_credentials is None:
-        raise RuntimeError("Azure credentials not initialized. Call initialize_azure_credentials first from main.py.")
-    return _azure_credentials
-
 def parse_narration_text(narration_text: str) -> Tuple[List[Dict[str, str]], List[str]]:
     """
-    Parses raw narration text into structured data for image and text elements.
+    Parses raw narration text into image descriptions and narration sentences.
 
     Args:
-        narration_text: The raw string output from the narration generation model.
+        narration_text: Raw output from the narration generation model.
 
     Returns:
-        A tuple containing:
-        - data: List of dicts ({"type": "image/text", "description/content": "..."}).
-        - narrations_list: List of just the narration sentences.
+        Tuple: (list of dicts for images/text, list of narration sentences).
     """
     data: List[Dict[str, str]] = []
     narrations_list: List[str] = []
@@ -60,34 +31,22 @@ def parse_narration_text(narration_text: str) -> Tuple[List[Dict[str, str]], Lis
 def create_narration_audio_files(
     data: List[Dict[str, str]],
     output_folder: str,
-    azure_subscription_key: Optional[str] = None, # Explicitly passed from AppConfig
-    azure_region: Optional[str] = None          # Explicitly passed from AppConfig
+    azure_subscription_key: Optional[str] = None,
+    azure_region: Optional[str] = None
 ) -> None:
     """
-    Generates narration audio files for each text element in the data.
+    Generates narration audio files using Azure TTS.
 
     Args:
-        data: Parsed data list from parse_narration_text.
-        output_folder: Directory to save narration MP3 files.
-        azure_subscription_key: Azure Speech Service API key.
-        azure_region: Azure Speech Service region.
+        data: Parsed data from parse_narration_text.
+        output_folder: Directory to save MP3 files.
+        azure_subscription_key: Azure Speech API key.
+        azure_region: Azure Speech region.
     """
     os.makedirs(output_folder, exist_ok=True)
 
-    key_to_use = azure_subscription_key
-    region_to_use = azure_region
-
-    if not key_to_use or not region_to_use:
-        try:
-            creds = _get_initialized_azure_credentials()
-            key_to_use = creds["api_key"]
-            region_to_use = creds["region"]
-        except RuntimeError as e:
-            print(f"Error: Azure credentials not provided and not initialized globally. {e} Skipping audio generation.")
-            return
-
-    if not key_to_use or not region_to_use:
-        print("Error: Azure API key or region missing. Skipping audio generation.")
+    if not azure_subscription_key or not azure_region:
+        print("Error: Azure API key or region not provided. Skipping audio generation.")
         return
 
     narration_count = 0
@@ -101,22 +60,25 @@ def create_narration_audio_files(
 
             output_file = os.path.join(output_folder, f"narration_{narration_count}.mp3")
             if os.path.exists(output_file):
-                print(f"{os.path.basename(output_file)} already exists. Skipping audio generation.")
+                print(f"Skipping existing audio: {os.path.basename(output_file)}")
                 continue
 
-            _generate_azure_tts_audio(content, output_file, key_to_use, region_to_use)
+            _generate_azure_tts_audio(content, output_file, azure_subscription_key, azure_region) # Use parameters directly
 
 def _generate_azure_tts_audio(
     text: str,
     output_filename: str,
-    subscription_key: str,
-    region: str
+    subscription_key: str, # Parameter name kept for clarity within this function
+    region: str            # Parameter name kept for clarity
 ) -> None:
-    """
-    Generates a single audio file from text using Azure Text-to-Speech.
-    """
+    """Generates a single audio file from text using Azure TTS."""
+    # Ensure parameters are not None before proceeding, though create_narration_audio_files should check
+    if not subscription_key or not region:
+        print(f"Error: Missing Azure credentials for generating {output_filename}.")
+        return
+
     ssml_text = f"""
-    <speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" 
+    <speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis"
            xmlns:mstts="http://www.w3.org/2001/mstts" xml:lang="en-GB">
       <voice name="en-GB-OllieMultilingualNeural">
         <mstts:express-as>


### PR DESCRIPTION
- Extracted hardcoded NARRATION_SYSTEM_PROMPT_TEXT into narration_prompt.txt.
- Modified AppConfig to load the prompt from this file by default, or from a path specified in JSON settings (NARRATION_SYSTEM_PROMPT_FILE).
- Simplified comments and print statements in main.py and short_narration.py for better readability and conciseness.
- Removed redundant global Azure credential handling in short_narration.py; credentials are now passed directly from AppConfig.